### PR TITLE
Fix cancellation of fruit spawning

### DIFF
--- a/Assets/Scripts/FruitSpawner.cs
+++ b/Assets/Scripts/FruitSpawner.cs
@@ -20,10 +20,10 @@ public class FruitSpawner : MonoBehaviour {
 		InvokeRepeating ("SpawnFruitGroups", 1f, 6f);
 	}
 
-	public void StopSpawning () {
-		CancelInvoke ("SpawnFruitGroup");
-		StopCoroutine ("SpawnFruit");
-	}
+        public void StopSpawning () {
+                CancelInvoke ("SpawnFruitGroups");
+                StopCoroutine ("SpawnFruit");
+        }
 
 	public void SpawnFruitGroups () {
 		StartCoroutine ("SpawnFruit");


### PR DESCRIPTION
## Summary
- fix method name used in `StopSpawning` so it properly cancels `SpawnFruitGroups`

## Testing
- `echo 'No tests present'`

------
https://chatgpt.com/codex/tasks/task_e_6841810f82248326afc2aedb7bf66379