### PR TITLE
Remove empty Unity lifecycle methods

### DIFF
--- a/Assets/Scripts/FruitScript.cs
+++ b/Assets/Scripts/FruitScript.cs
@@ -7,15 +7,7 @@ public class FruitScript : MonoBehaviour {
 	public GameObject cut1;
 	public GameObject cut2;
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
+       // Use this for initialization
 
 	void OnCollisionEnter2D (Collision2D target) {
 		if (target.gameObject.tag == "Line") {

--- a/Assets/Scripts/FruitSpawner.cs
+++ b/Assets/Scripts/FruitSpawner.cs
@@ -12,9 +12,6 @@ public class FruitSpawner : MonoBehaviour {
 		Invoke ("StartSpawning", 1f);
 	}
 
-	void Update () {
-		
-	}
 
 	public void StartSpawning () {
 		InvokeRepeating ("SpawnFruitGroups", 1f, 6f);

--- a/Assets/Scripts/LineCreator.cs
+++ b/Assets/Scripts/LineCreator.cs
@@ -16,9 +16,6 @@ public class LineCreator : MonoBehaviour {
 		line = GetComponent<LineRenderer> ();
 	}
 
-	void Start () {
-		
-	}
 
 	void Update () {
 		// Android specific code


### PR DESCRIPTION
## Summary
- delete unused `Start` and `Update` methods in `FruitScript`
- remove unused `Update` in `FruitSpawner`
- remove unused `Start` in `LineCreator`

## Testing
- `mcs Assets/Scripts/*.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841810fba5083268a5832d9525e6f33