### PR TITLE
Fix countdown timer frame rate dependence

### DIFF
--- a/Assets/Scripts/GameplayController.cs
+++ b/Assets/Scripts/GameplayController.cs
@@ -47,9 +47,9 @@ public class GameplayController : MonoBehaviour {
 		}
 	}
 
-	void CountDownAndBeginLevel () {
-		countDownTimer -= (0.19f * 0.15f);
-		countDownText.text = countDownTimer.ToString ("F0");
+        void CountDownAndBeginLevel () {
+                countDownTimer -= Time.deltaTime * 0.15f;
+                countDownText.text = countDownTimer.ToString ("F0");
 
 		if (countDownTimer <= 0) {
 			Time.timeScale = 1;


### PR DESCRIPTION
## Summary
- update the countdown timer to use `Time.deltaTime`

## Testing
- `true` (no tests in repo)


------
https://chatgpt.com/codex/tasks/task_e_6841811113b88326b3607e0fccf2fadf